### PR TITLE
Fixed typo in convert_tensor() function

### DIFF
--- a/clip_trt/utils/tensor.py
+++ b/clip_trt/utils/tensor.py
@@ -145,7 +145,7 @@ def convert_tensor(tensor, return_tensors='pt', device=None, dtype=None, **kwarg
         elif return_tensors == 'pt':
             return torch.as_tensor(tensor, dtype=dtype, device=device)
         elif return_tensors == 'list':
-            return tensors
+            return tensor
                        
     raise ValueError(f"unsupported tensor input/output type (in={type(tensor)} out={return_tensors})")
 


### PR DESCRIPTION
Corrected typo in convert_tensor() to correctly handle return_tensors='list' by replacing `tensors` with `tensor`