### PR TITLE
Importing requests module in image.py

### DIFF
--- a/clip_trt/utils/image.py
+++ b/clip_trt/utils/image.py
@@ -2,6 +2,7 @@
 import io
 import PIL
 import logging
+import requests
 import torch
 import torchvision.transforms.functional as F
 


### PR DESCRIPTION
the [requests](https://pypi.org/project/requests/) module is getting used in [image.py](https://github.com/dusty-nv/clip_trt/blob/main/clip_trt/utils/image.py#L62) without getting imported. This PR fixes it.